### PR TITLE
Handle 503 'Service Temporaily Unavailable' errors

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -26,7 +26,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
              */
             $response = $event['response'];
 
-            if ($response->isClientError()) {
+            if ($response->isError()) {
                 $event->stopPropagation();
             }
         });

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -79,4 +79,32 @@ class PurchaseRequestTest extends TestCase
         $this->assertNull($response->getRedirectData());
         $this->assertSame("The issuer is invalid", $response->getMessage());
     }
+
+    public function testIssuerFailure()
+    {
+        $this->setMockHttpResponse('PurchaseIssuerFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertInstanceOf('Omnipay\Mollie\Message\PurchaseResponse', $response);
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getRedirectUrl());
+        $this->assertNull($response->getRedirectData());
+        $this->assertSame("Issuer failure", $response->getMessage());
+    }
+
+    public function testSystemFailure()
+    {
+        $this->setMockHttpResponse('PurchaseSystemFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertInstanceOf('Omnipay\Mollie\Message\PurchaseResponse', $response);
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getRedirectUrl());
+        $this->assertNull($response->getRedirectData());
+        $this->assertSame("Payment platform for this payment method temporarily not available", $response->getMessage());
+    }
 }

--- a/tests/Mock/PurchaseIssuerFailure.txt
+++ b/tests/Mock/PurchaseIssuerFailure.txt
@@ -1,0 +1,19 @@
+HTTP/1.1 503 Service Temporarily Unavailable
+Server: nginx/1.4.4
+Date: Mon, 20 Jan 2014 10:19:39 GMT
+Content-Type: application/json; charset=utf-8
+Content-Length: 101
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE
+Access-Control-Max-Age: 300
+Cache-Control: no-cache, no-store
+Strict-Transport-Security: max-age=31556926; includeSubDomains
+
+{
+  "error":{
+    "type":"system",
+    "message":"Issuer failure",
+    "field":"issuer"
+  }
+}

--- a/tests/Mock/PurchaseSystemFailure.txt
+++ b/tests/Mock/PurchaseSystemFailure.txt
@@ -1,0 +1,18 @@
+HTTP/1.1 503 Service Temporarily Unavailable
+Server: nginx/1.4.4
+Date: Mon, 20 Jan 2014 10:19:39 GMT
+Content-Type: application/json; charset=utf-8
+Content-Length: 101
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE
+Access-Control-Max-Age: 300
+Cache-Control: no-cache, no-store
+Strict-Transport-Security: max-age=31556926; includeSubDomains
+
+{
+  "error":{
+    "type":"system",
+    "message":"Payment platform for this payment method temporarily not available"
+  }
+}


### PR DESCRIPTION
This PR fixes the handling of 503 errors:
- when Mollie is down it will return a 503 error;
- when you try to setup a payment via iDEAL with a direct issuer and the issuer is down, Mollie will return a 503 with a different error message.

Please merge-and-tag a new release :)
