### PR TITLE
Allowance for webhookUrl parameter.

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -38,7 +38,7 @@ class Gateway extends AbstractGateway
     }
 
     /**
-     * @param string $value
+     * @param  string $value
      * @return $this
      */
     public function setApiKey($value)

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -22,7 +22,7 @@ class PurchaseRequest extends AbstractRequest
     public function getData()
     {
         $this->validate('apiKey', 'amount', 'description', 'returnUrl');
-        
+
         $data = array();
         $data['amount'] = $this->getAmount();
         $data['description'] = $this->getDescription();
@@ -30,19 +30,19 @@ class PurchaseRequest extends AbstractRequest
         $data['method'] = $this->getPaymentMethod();
         $data['metadata'] = $this->getMetadata();
         $data['issuer'] = $this->getIssuer();
-        
+
         $webhookUrl = $this->getNotifyUrl();
         if (null !== $webhookUrl) {
             $data['webhookUrl'] = $webhookUrl;
         }
-        
+
         return $data;
     }
 
     public function sendData($data)
     {
         $httpResponse = $this->sendRequest('POST', '/payments', $data);
-        
+
         return $this->response = new PurchaseResponse($this, $httpResponse->json());
     }
 }

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -37,9 +37,9 @@ class PurchaseRequestTest extends TestCase
             'metadata'      => 'meta',
             'issuer'        => 'my bank'
         ));
-        
+
         $data = $this->request->getData();
-        
+
         $this->assertSame("12.00", $data['amount']);
         $this->assertSame('Description', $data['description']);
         $this->assertSame('https://www.example.com/return', $data['redirectUrl']);
@@ -61,9 +61,9 @@ class PurchaseRequestTest extends TestCase
             'issuer'        => 'my bank',
             'notifyUrl'    => 'https://www.example.com/hook'
         ));
-        
+
         $data = $this->request->getData();
-        
+
         $this->assertSame("12.00", $data['amount']);
         $this->assertSame('Description', $data['description']);
         $this->assertSame('https://www.example.com/return', $data['redirectUrl']);
@@ -78,7 +78,7 @@ class PurchaseRequestTest extends TestCase
     {
         $this->setMockHttpResponse('PurchaseSuccess.txt');
         $response = $this->request->send();
-        
+
         $this->assertInstanceOf('Omnipay\Mollie\Message\PurchaseResponse', $response);
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
@@ -96,7 +96,7 @@ class PurchaseRequestTest extends TestCase
     {
         $this->setMockHttpResponse('PurchaseFailure.txt');
         $response = $this->request->send();
-        
+
         $this->assertInstanceOf('Omnipay\Mollie\Message\PurchaseResponse', $response);
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());


### PR DESCRIPTION
The Mollie API has a webhookUrl parameter. This allows to change the callback that Mollie does after a successful payment. The default hook can be set in the Mollie admin panel. Test is included.

For more info, please see.
https://www.mollie.nl/files/documentatie/payments-api.html
