### PR TITLE
Validate transactionReference instead of id

### DIFF
--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -13,18 +13,10 @@ class CompletePurchaseRequest extends FetchTransactionRequest
 {
     public function getData()
     {
-        $this->validate('apiKey');
+        $this->validate('apiKey', 'transactionReference');
 
         $data = array();
         $data['id'] = $this->getTransactionReference();
-
-        if (!isset($data['id'])) {
-            $data['id'] = $this->httpRequest->request->get('id');
-        }
-
-        if (empty($data['id'])) {
-            throw new InvalidRequestException("The id parameter is required");
-        }
 
         return $data;
     }


### PR DESCRIPTION
When is the 'id' parameter passed to the query? In some tests, where I define the returnUrl, no id is added to the url.
Also, the message talks about `id`, but a transactionReference parameter is needed.

If the `?id=123` is added, please close this PR, but change the exception message to indicate that the transactionReference is needed, not some 'id' parameter.
