### PR TITLE
Issuer should only be specified if used.

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -29,7 +29,11 @@ class PurchaseRequest extends AbstractRequest
         $data['redirectUrl'] = $this->getReturnUrl();
         $data['method'] = $this->getPaymentMethod();
         $data['metadata'] = $this->getMetadata();
-        $data['issuer'] = $this->getIssuer();
+        
+        $issuer = $this->getIssuer();
+        if ($issuer) {
+            $data['issuer'] = $issuer;
+        }
 
         $webhookUrl = $this->getNotifyUrl();
         if (null !== $webhookUrl) {


### PR DESCRIPTION
If an empty/NULL issuer is sent the purchase request will return an error: Invalid Issuer