### PR TITLE
Throw exception for cancelUrl

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Omnipay\Mollie\Message;
 
+use Omnipay\Common\Exception\RuntimeException;
+
 /**
  * Mollie Purchase Request
  *
@@ -30,6 +32,10 @@ class PurchaseRequest extends AbstractRequest
         $data['method'] = $this->getPaymentMethod();
         $data['metadata'] = $this->getMetadata();
         $data['issuer'] = $this->getIssuer();
+
+        if (null !== $this->getCancelUrl()) {
+            throw new RuntimeException ('Mollie does not support a cancel url.');
+        }
 
         $webhookUrl = $this->getNotifyUrl();
         if (null !== $webhookUrl) {

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -34,7 +34,7 @@ class PurchaseRequest extends AbstractRequest
         $data['issuer'] = $this->getIssuer();
 
         if (null !== $this->getCancelUrl()) {
-            throw new RuntimeException ('Mollie does not support a cancel url.');
+            throw new RuntimeException('Mollie does not support a cancel url.');
         }
 
         $webhookUrl = $this->getNotifyUrl();


### PR DESCRIPTION
Use completePurchase() to validate the success or failure of a Mollie payment.

```
$request = $gateway->completePurchase();
$request->setTransactionReference($transactionReference);
$response = $request->send();
if ($response->isSuccessful()) {
    // success
} else {
    // failure
}
```

This cost me some time to find out why the cancelUrl parameter was not working as expected. This will helps others spending time on the same issue.