### PR TITLE
Require transactionReference in CompletePurchaseRequest

### DIFF
--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -13,18 +13,10 @@ class CompletePurchaseRequest extends FetchTransactionRequest
 {
     public function getData()
     {
-        $this->validate('apiKey');
+        $this->validate('apiKey', 'transactionReference');
 
         $data = array();
         $data['id'] = $this->getTransactionReference();
-
-        if (!isset($data['id'])) {
-            $data['id'] = $this->httpRequest->request->get('id');
-        }
-
-        if (empty($data['id'])) {
-            throw new InvalidRequestException("The transactionReference parameter is required");
-        }
 
         return $data;
     }


### PR DESCRIPTION
Issue: https://github.com/thephpleague/omnipay-mollie/issues/27

For consistency, validate the presence of transactionReference in the parameters instead of trying to get it first via getTransactionReference(), then -if empty- getting the id-parameter from the request (as it is sent by Mollie when using the webhook) and if still not present throwing an exception.

This way, all calls using omnipay-mollie look and feel the same and the user self is responsible for sending:

```
$params = [
    'transactionReference' => $_POST['id'] // or whatever method used to get the parameter from the POST-request
];
```