### PR TITLE
Add support for Refund descriptions

### DIFF
--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -8,6 +8,11 @@ use Omnipay\Common\Message\ResponseInterface;
 
 class RefundRequest extends AbstractRequest
 {
+    public function getRefundDescription()
+    {
+        return $this->getParameter('description');
+    }
+
     public function getData()
     {
         $this->validate('apiKey', 'transactionReference');
@@ -15,6 +20,10 @@ class RefundRequest extends AbstractRequest
         $data = array();
         if ($this->getAmountInteger() > 0) {
             $data['amount'] = $this->getAmount();
+        }
+
+        if (null !== $this->getRefundDescription()) {
+            $data['description'] = $this->getRefundDescription();
         }
 
         return $data;

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -53,6 +53,24 @@ class RefundRequestTest extends TestCase
         $this->assertCount(0, $data);
     }
 
+    public function testGetDataWithDescription()
+    {
+        $this->request->initialize(
+            array(
+                'apiKey'               => 'mykey',
+                'amount'               => '12.00',
+                'description'          => 'Custom description',
+                'transactionReference' => 'tr_WDqYK6vllg'
+            )
+        );
+
+        $data = $this->request->getData();
+
+        $this->assertSame("12.00", $data['amount']);
+        $this->assertSame("Custom description", $data['description']);
+        $this->assertCount(2, $data);
+    }
+
     public function testSendSuccess()
     {
         $this->setMockHttpResponse('RefundSuccess.txt');

--- a/tests/Mock/RefundSuccess.txt
+++ b/tests/Mock/RefundSuccess.txt
@@ -39,5 +39,6 @@ X-Whom: dc1-web-2
         }
     },
     "amount": "5.95",
+    "description": "My first payment",
     "refundedDatetime": "2016-08-19T08:49:58.0Z"
 }

--- a/tests/Mock/RefundSuccess.txt
+++ b/tests/Mock/RefundSuccess.txt
@@ -39,6 +39,6 @@ X-Whom: dc1-web-2
         }
     },
     "amount": "5.95",
-    "description": "My first payment",
+    "description": "Order",
     "refundedDatetime": "2016-08-19T08:49:58.0Z"
 }


### PR DESCRIPTION
Mollie now supports (optionally) a custom refund description. If you don't pass one to the RefundRequest, the payment description will be used, but description is always returned.
