### PR TITLE
Updated composer & AbstractRequest to start using omnipay/common 3-simple

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,33 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
 
-before_script:
-  - composer install -n --dev --prefer-source
+# This triggers builds to run on the new TravisCI infrastructure.
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+## Cache composer
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+env:
+  global:
+    - setup=basic
+
+matrix:
+  include:
+    - php: 5.6
+      env: setup=lowest
+    - php: 7.0
+      env: setup=lowest
+
+install:
+  - if [[ $setup = 'basic' ]]; then travis_retry composer install --prefer-dist --no-interaction; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
 
 script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "omnipay/common": "^3"
     },
     "require-dev": {
-        "omnipay/tests": "^3"
+        "omnipay/tests": "^3",
+        "squizlabs/php_codesniffer": "^2.8.1"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,12 @@
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         }
-    }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "check-style": "phpcs -p --standard=PSR2 src/",
+        "fix-style": "phpcbf -p --standard=PSR2 src/"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
         "psr-4": { "Omnipay\\Mollie\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.2"
+        "omnipay/common": "dev-3.0-simple"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "3.0.x-dev"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,10 @@
         "psr-4": { "Omnipay\\Mollie\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "dev-3.0-simple",
-        "php-http/guzzle6-adapter": "~1.1.1"
+        "omnipay/common": "^3"
     },
     "require-dev": {
-        "omnipay/tests": "3.0.x-dev"
+        "omnipay/tests": "^3"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "psr-4": { "Omnipay\\Mollie\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "dev-3.0-simple"
+        "omnipay/common": "dev-3.0-simple",
+        "php-http/guzzle6-adapter": "~1.1.1"
     },
     "require-dev": {
         "omnipay/tests": "3.0.x-dev"

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -2,8 +2,6 @@
 
 namespace Omnipay\Mollie\Message;
 
-use Guzzle\Common\Event;
-
 abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 {
     protected $endpoint = 'https://api.mollie.nl/v1';
@@ -30,26 +28,15 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     protected function sendRequest($method, $endpoint, $data = null)
     {
-        $this->httpClient->getEventDispatcher()->addListener('request.error', function (Event $event) {
-            /**
-             * @var \Guzzle\Http\Message\Response $response
-             */
-            $response = $event['response'];
-
-            if ($response->isError()) {
-                $event->stopPropagation();
-            }
-        });
-
         $httpRequest = $this->httpClient->createRequest(
             $method,
             $this->endpoint . $endpoint,
             array(
                 'Authorization' => 'Bearer ' . $this->getApiKey()
             ),
-            $data
+            json_encode($data)
         );
 
-        return $httpRequest->send();
+        return $this->httpClient->sendRequest($httpRequest);
     }
 }

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Mollie\Message;
 
 use Omnipay\Common\Exception\InvalidRequestException;
+use Omnipay\Common\Http\Decoder;
 
 /**
  * Mollie Complete Purchase Request
@@ -33,6 +34,6 @@ class CompletePurchaseRequest extends FetchTransactionRequest
     {
         $httpResponse = $this->sendRequest('GET', '/payments/' . $data['id']);
 
-        return $this->response = new CompletePurchaseResponse($this, $httpResponse->json());
+        return $this->response = new CompletePurchaseResponse($this, Decoder::json($httpResponse));
     }
 }

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -3,7 +3,7 @@
 namespace Omnipay\Mollie\Message;
 
 use Omnipay\Common\Exception\InvalidRequestException;
-use Omnipay\Common\Http\Decoder;
+use Omnipay\Common\Http\ResponseParser;
 
 /**
  * Mollie Complete Purchase Request
@@ -34,6 +34,6 @@ class CompletePurchaseRequest extends FetchTransactionRequest
     {
         $httpResponse = $this->sendRequest('GET', '/payments/' . $data['id']);
 
-        return $this->response = new CompletePurchaseResponse($this, Decoder::json($httpResponse));
+        return $this->response = new CompletePurchaseResponse($this, ResponseParser::json($httpResponse));
     }
 }

--- a/src/Message/CreateCustomerRequest.php
+++ b/src/Message/CreateCustomerRequest.php
@@ -7,7 +7,7 @@
  */
 namespace Omnipay\Mollie\Message;
 
-use Omnipay\Common\Http\Decoder;
+use Omnipay\Common\Http\ResponseParser;
 
 class CreateCustomerRequest extends AbstractRequest
 {
@@ -102,7 +102,7 @@ class CreateCustomerRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('POST', '/customers', $data);
 
-        return $this->response = new CreateCustomerResponse($this, Decoder::json($httpResponse));
+        return $this->response = new CreateCustomerResponse($this, ResponseParser::json($httpResponse));
     }
 
     /**

--- a/src/Message/CreateCustomerRequest.php
+++ b/src/Message/CreateCustomerRequest.php
@@ -7,6 +7,8 @@
  */
 namespace Omnipay\Mollie\Message;
 
+use Omnipay\Common\Http\Decoder;
+
 class CreateCustomerRequest extends AbstractRequest
 {
     /**
@@ -100,7 +102,7 @@ class CreateCustomerRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('POST', '/customers', $data);
 
-        return $this->response = new CreateCustomerResponse($this, $httpResponse->json());
+        return $this->response = new CreateCustomerResponse($this, Decoder::json($httpResponse));
     }
 
     /**

--- a/src/Message/FetchCustomerRequest.php
+++ b/src/Message/FetchCustomerRequest.php
@@ -7,6 +7,8 @@
  */
 namespace Omnipay\Mollie\Message;
 
+use Omnipay\Common\Http\Decoder;
+
 class FetchCustomerRequest extends AbstractRequest
 {
     /**
@@ -44,7 +46,7 @@ class FetchCustomerRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('GET', '/customers/' . $this->getCustomerReference(), $data);
 
-        return $this->response = new FetchCustomerResponse($this, $httpResponse->json());
+        return $this->response = new FetchCustomerResponse($this, Decoder::json($httpResponse));
     }
 
     /**

--- a/src/Message/FetchCustomerRequest.php
+++ b/src/Message/FetchCustomerRequest.php
@@ -7,7 +7,7 @@
  */
 namespace Omnipay\Mollie\Message;
 
-use Omnipay\Common\Http\Decoder;
+use Omnipay\Common\Http\ResponseParser;
 
 class FetchCustomerRequest extends AbstractRequest
 {
@@ -46,7 +46,7 @@ class FetchCustomerRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('GET', '/customers/' . $this->getCustomerReference(), $data);
 
-        return $this->response = new FetchCustomerResponse($this, Decoder::json($httpResponse));
+        return $this->response = new FetchCustomerResponse($this, ResponseParser::json($httpResponse));
     }
 
     /**

--- a/src/Message/FetchIssuersRequest.php
+++ b/src/Message/FetchIssuersRequest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Mollie\Message;
 
-use Omnipay\Common\Http\Decoder;
+use Omnipay\Common\Http\ResponseParser;
 
 /**
  * Mollie Fetch Issuers Request
@@ -23,6 +23,6 @@ class FetchIssuersRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('GET', '/issuers');
 
-        return $this->response = new FetchIssuersResponse($this, Decoder::json($httpResponse));
+        return $this->response = new FetchIssuersResponse($this, ResponseParser::json($httpResponse));
     }
 }

--- a/src/Message/FetchIssuersRequest.php
+++ b/src/Message/FetchIssuersRequest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Omnipay\Mollie\Message;
+
 use Omnipay\Common\Http\Decoder;
 
 /**

--- a/src/Message/FetchIssuersRequest.php
+++ b/src/Message/FetchIssuersRequest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Omnipay\Mollie\Message;
+use Omnipay\Common\Http\Decoder;
 
 /**
  * Mollie Fetch Issuers Request
@@ -21,6 +22,6 @@ class FetchIssuersRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('GET', '/issuers');
 
-        return $this->response = new FetchIssuersResponse($this, $httpResponse->json());
+        return $this->response = new FetchIssuersResponse($this, Decoder::json($httpResponse));
     }
 }

--- a/src/Message/FetchPaymentMethodsRequest.php
+++ b/src/Message/FetchPaymentMethodsRequest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Omnipay\Mollie\Message;
+use Omnipay\Common\Http\Decoder;
 
 /**
  * Mollie Fetch PaymentMethods Request
@@ -21,6 +22,6 @@ class FetchPaymentMethodsRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('GET', '/methods');
 
-        return $this->response = new FetchPaymentMethodsResponse($this, $httpResponse->json());
+        return $this->response = new FetchPaymentMethodsResponse($this, Decoder::json($httpResponse));
     }
 }

--- a/src/Message/FetchPaymentMethodsRequest.php
+++ b/src/Message/FetchPaymentMethodsRequest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Omnipay\Mollie\Message;
+
 use Omnipay\Common\Http\Decoder;
 
 /**

--- a/src/Message/FetchPaymentMethodsRequest.php
+++ b/src/Message/FetchPaymentMethodsRequest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Mollie\Message;
 
-use Omnipay\Common\Http\Decoder;
+use Omnipay\Common\Http\ResponseParser;
 
 /**
  * Mollie Fetch PaymentMethods Request
@@ -23,6 +23,6 @@ class FetchPaymentMethodsRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('GET', '/methods');
 
-        return $this->response = new FetchPaymentMethodsResponse($this, Decoder::json($httpResponse));
+        return $this->response = new FetchPaymentMethodsResponse($this, ResponseParser::json($httpResponse));
     }
 }

--- a/src/Message/FetchTransactionRequest.php
+++ b/src/Message/FetchTransactionRequest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Omnipay\Mollie\Message;
+
 use Omnipay\Common\Http\Decoder;
 
 /**

--- a/src/Message/FetchTransactionRequest.php
+++ b/src/Message/FetchTransactionRequest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Omnipay\Mollie\Message;
+use Omnipay\Common\Http\Decoder;
 
 /**
  * Mollie Fetch Transaction Request
@@ -23,6 +24,6 @@ class FetchTransactionRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('GET', '/payments/' . $data['id']);
 
-        return $this->response = new FetchTransactionResponse($this, $httpResponse->json());
+        return $this->response = new FetchTransactionResponse($this, Decoder::json($httpResponse));
     }
 }

--- a/src/Message/FetchTransactionRequest.php
+++ b/src/Message/FetchTransactionRequest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Mollie\Message;
 
-use Omnipay\Common\Http\Decoder;
+use Omnipay\Common\Http\ResponseParser;
 
 /**
  * Mollie Fetch Transaction Request
@@ -25,6 +25,6 @@ class FetchTransactionRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('GET', '/payments/' . $data['id']);
 
-        return $this->response = new FetchTransactionResponse($this, Decoder::json($httpResponse));
+        return $this->response = new FetchTransactionResponse($this, ResponseParser::json($httpResponse));
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Omnipay\Mollie\Message;
+
 use Omnipay\Common\Http\Decoder;
 
 /**
@@ -9,7 +10,6 @@ use Omnipay\Common\Http\Decoder;
  */
 class PurchaseRequest extends AbstractRequest
 {
-
     public function getMetadata()
     {
         return $this->getParameter('metadata');

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Omnipay\Mollie\Message;
+use Omnipay\Common\Http\Decoder;
 
 /**
  * Mollie Purchase Request
@@ -49,6 +50,6 @@ class PurchaseRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('POST', '/payments', $data);
 
-        return $this->response = new PurchaseResponse($this, $httpResponse->json());
+        return $this->response = new PurchaseResponse($this, Decoder::json($httpResponse));
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Omnipay\Mollie\Message;
 
-use Omnipay\Common\Http\Decoder;
+use Omnipay\Common\Http\ResponseParser;
 
 /**
  * Mollie Purchase Request
@@ -50,6 +50,6 @@ class PurchaseRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('POST', '/payments', $data);
 
-        return $this->response = new PurchaseResponse($this, Decoder::json($httpResponse));
+        return $this->response = new PurchaseResponse($this, ResponseParser::json($httpResponse));
     }
 }

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -3,7 +3,6 @@
 
 namespace Omnipay\Mollie\Message;
 
-
 use Omnipay\Common\Http\Decoder;
 use Omnipay\Common\Message\ResponseInterface;
 

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -4,6 +4,7 @@
 namespace Omnipay\Mollie\Message;
 
 
+use Omnipay\Common\Http\Decoder;
 use Omnipay\Common\Message\ResponseInterface;
 
 class RefundRequest extends AbstractRequest
@@ -24,6 +25,6 @@ class RefundRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('POST', '/payments/' . $this->getTransactionReference() . '/refunds', $data);
 
-        return $this->response = new RefundResponse($this, $httpResponse->json());
+        return $this->response = new RefundResponse($this, Decoder::json($httpResponse));
     }
 }

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -3,8 +3,7 @@
 
 namespace Omnipay\Mollie\Message;
 
-use Omnipay\Common\Http\Decoder;
-use Omnipay\Common\Message\ResponseInterface;
+use Omnipay\Common\Http\ResponseParser;
 
 class RefundRequest extends AbstractRequest
 {
@@ -24,6 +23,6 @@ class RefundRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('POST', '/payments/' . $this->getTransactionReference() . '/refunds', $data);
 
-        return $this->response = new RefundResponse($this, Decoder::json($httpResponse));
+        return $this->response = new RefundResponse($this, ResponseParser::json($httpResponse));
     }
 }

--- a/src/Message/RefundResponse.php
+++ b/src/Message/RefundResponse.php
@@ -3,7 +3,6 @@
 
 namespace Omnipay\Mollie\Message;
 
-
 class RefundResponse extends AbstractResponse
 {
     public function getTransactionReference()

--- a/src/Message/UpdateCustomerRequest.php
+++ b/src/Message/UpdateCustomerRequest.php
@@ -7,6 +7,8 @@
  */
 namespace Omnipay\Mollie\Message;
 
+use Omnipay\Common\Http\Decoder;
+
 class UpdateCustomerRequest extends AbstractRequest
 {
     /**
@@ -120,7 +122,7 @@ class UpdateCustomerRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('POST', '/customers/'.$this->getCustomerReference(), $data);
 
-        return $this->response = new UpdateCustomerResponse($this, $httpResponse->json());
+        return $this->response = new UpdateCustomerResponse($this, Decoder::json($httpResponse));
     }
 
     /**

--- a/src/Message/UpdateCustomerRequest.php
+++ b/src/Message/UpdateCustomerRequest.php
@@ -7,7 +7,7 @@
  */
 namespace Omnipay\Mollie\Message;
 
-use Omnipay\Common\Http\Decoder;
+use Omnipay\Common\Http\ResponseParser;
 
 class UpdateCustomerRequest extends AbstractRequest
 {
@@ -122,7 +122,7 @@ class UpdateCustomerRequest extends AbstractRequest
     {
         $httpResponse = $this->sendRequest('POST', '/customers/'.$this->getCustomerReference(), $data);
 
-        return $this->response = new UpdateCustomerResponse($this, Decoder::json($httpResponse));
+        return $this->response = new UpdateCustomerResponse($this, ResponseParser::json($httpResponse));
     }
 
     /**


### PR DESCRIPTION
Updated composer to use omnipay/common 3.
Using the: php-http/guzzle6-adapter

After this update, this bundle can be used in for example a Symfony3 project.
I don't know if master is the correct branch and if this fits i nyour upgrade path. But I just want to give it a try! :-)

Tested it locally with the ruudk/payment-mollie-bundle in Symfony 3.2.