### PR TITLE
Add the 'locale' and 'billingEmail' parameters

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -20,6 +20,26 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('metadata', $value);
     }
 
+    public function getLocale()
+    {
+        return $this->getParameter('locale');
+    }
+
+    public function setLocale($value)
+    {
+        return $this->setParameter('locale', $value);
+    }
+
+    public function getBillingEmail()
+    {
+        return $this->getParameter('billingEmail');
+    }
+
+    public function setBillingEmail($value)
+    {
+        return $this->setParameter('billingEmail', $value);
+    }
+
     public function getData()
     {
         $this->validate('apiKey', 'amount', 'description', 'returnUrl');
@@ -30,17 +50,26 @@ class PurchaseRequest extends AbstractRequest
         $data['redirectUrl'] = $this->getReturnUrl();
         $data['method']      = $this->getPaymentMethod();
         $data['metadata']    = $this->getMetadata();
+
         if ($this->getTransactionId()) {
             $data['metadata']['transactionId'] = $this->getTransactionId();
         }
-        $issuer = $this->getIssuer();
-        if ($issuer) {
+
+        if ($issuer = $this->getIssuer()) {
             $data['issuer'] = $issuer;
         }
 
         $webhookUrl = $this->getNotifyUrl();
         if (null !== $webhookUrl) {
             $data['webhookUrl'] = $webhookUrl;
+        }
+
+        if ($locale = $this->getLocale()) {
+            $data['locale'] = $locale;
+        }
+
+        if ($billingEmail = $this->getBillingEmail()) {
+            $data['billingEmail'] = $billingEmail;
         }
 
         return $data;

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -16,13 +16,15 @@ class PurchaseRequestTest extends TestCase
     {
         $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(array(
-            'apiKey'      => 'mykey',
-            'amount'      => '12.00',
-            'issuer'      => 'my bank',
-            'description' => 'Description',
-            'returnUrl'   => 'https://www.example.com/return',
-            'method'      => 'ideal',
-            'metadata'    => 'meta',
+            'apiKey'       => 'mykey',
+            'amount'       => '12.00',
+            'issuer'       => 'my bank',
+            'description'  => 'Description',
+            'returnUrl'    => 'https://www.example.com/return',
+            'method'       => 'ideal',
+            'metadata'     => 'meta',
+            'locale'       => 'fr_FR',
+            'billingEmail' => 'billing-email@example.com',
         ));
     }
 
@@ -36,6 +38,8 @@ class PurchaseRequestTest extends TestCase
             'paymentMethod' => 'ideal',
             'metadata'      => 'meta',
             'issuer'        => 'my bank',
+            'locale'        => 'fr_FR',
+            'billingEmail'  => 'billing-email@example.com',
         ));
 
         $data = $this->request->getData();
@@ -46,7 +50,9 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('ideal', $data['method']);
         $this->assertSame('meta', $data['metadata']);
         $this->assertSame('my bank', $data['issuer']);
-        $this->assertCount(6, $data);
+        $this->assertSame('fr_FR', $data['locale']);
+        $this->assertSame('billing-email@example.com', $data['billingEmail']);
+        $this->assertCount(8, $data);
     }
 
     public function testGetDataWithWebhook()
@@ -59,6 +65,8 @@ class PurchaseRequestTest extends TestCase
             'paymentMethod' => 'ideal',
             'metadata'      => 'meta',
             'issuer'        => 'my bank',
+            'locale'        => 'fr_FR',
+            'billingEmail'  => 'billing-email@example.com',
             'notifyUrl'     => 'https://www.example.com/hook',
         ));
 
@@ -70,8 +78,10 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('ideal', $data['method']);
         $this->assertSame('meta', $data['metadata']);
         $this->assertSame('my bank', $data['issuer']);
+        $this->assertSame('fr_FR', $data['locale']);
+        $this->assertSame('billing-email@example.com', $data['billingEmail']);
         $this->assertSame('https://www.example.com/hook', $data['webhookUrl']);
-        $this->assertCount(7, $data);
+        $this->assertCount(9, $data);
     }
 
     public function testNoIssuer()
@@ -83,6 +93,8 @@ class PurchaseRequestTest extends TestCase
             'returnUrl'     => 'https://www.example.com/return',
             'paymentMethod' => 'ideal',
             'metadata'      => 'meta',
+            'locale'        => 'fr_FR',
+            'billingEmail'  => 'billing-email@example.com',
             'notifyUrl'     => 'https://www.example.com/hook',
         ));
 
@@ -93,8 +105,10 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('https://www.example.com/return', $data['redirectUrl']);
         $this->assertSame('ideal', $data['method']);
         $this->assertSame('meta', $data['metadata']);
+        $this->assertSame('fr_FR', $data['locale']);
+        $this->assertSame('billing-email@example.com', $data['billingEmail']);
         $this->assertSame('https://www.example.com/hook', $data['webhookUrl']);
-        $this->assertCount(6, $data);
+        $this->assertCount(8, $data);
     }
 
     public function testSendSuccess()


### PR DESCRIPTION
Adds support for the `locale` and `billingEmail` parameters.

https://www.mollie.com/nl/docs/reference/payments/create

`locale`

> Allow you to preset the language to be used in the payment screens shown to the consumer. When this  parameter is not provided, the browser language will be used instead (which is usually more accurate). 


`billingEmail` parameter:

> Consumer's email address, to automatically send the bank transfer details to. Please note: the payment instructions will be sent immediately when creating the payment. If you don't specify the locale parameter, the email will be sent in English, as we haven't yet been able to detect the consumer's browser language.