### PR TITLE
Drop hhvm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/


### PR DESCRIPTION
Just a thought as major packages are dropping HHVM as well, and is currently throwing Travis errors.

> HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.