### PR TITLE
FetchPaymentMethodsRequest parameters

### DIFF
--- a/src/Message/Request/FetchPaymentMethodsRequest.php
+++ b/src/Message/Request/FetchPaymentMethodsRequest.php
@@ -14,6 +14,23 @@ use Omnipay\Mollie\Message\Response\FetchPaymentMethodsResponse;
 class FetchPaymentMethodsRequest extends AbstractMollieRequest
 {
     /**
+     * @param string $resource
+     * @return $this
+     */
+    public function setResource(string $resource)
+    {
+        return $this->setParameter('resource', $resource);
+    }
+
+    /**
+     * @return string
+     */
+    public function getResource()
+    {
+        return $this->getParameter('resource');
+    }
+
+    /**
      * @return array
      * @throws InvalidRequestException
      */
@@ -21,7 +38,9 @@ class FetchPaymentMethodsRequest extends AbstractMollieRequest
     {
         $this->validate('apiKey');
 
-        return [];
+        return [
+            'resource' => $this->getResource(),
+        ];
     }
 
     /**
@@ -30,7 +49,11 @@ class FetchPaymentMethodsRequest extends AbstractMollieRequest
      */
     public function sendData($data)
     {
-        $response = $this->sendRequest(self::GET, '/methods');
+        $query = http_build_query($data);
+        $response = $this->sendRequest(self::GET, sprintf(
+            '/methods%s',
+            ($query ? '?' . $query : '')
+        ));
 
         return $this->response = new FetchPaymentMethodsResponse($this, $response);
     }

--- a/src/Message/Request/FetchPaymentMethodsRequest.php
+++ b/src/Message/Request/FetchPaymentMethodsRequest.php
@@ -14,10 +14,44 @@ use Omnipay\Mollie\Message\Response\FetchPaymentMethodsResponse;
 class FetchPaymentMethodsRequest extends AbstractMollieRequest
 {
     /**
+     * @param string $billingCountry
+     * @return $this
+     */
+    public function setBillingCountry($billingCountry)
+    {
+        return $this->setParameter('billingCountry', $billingCountry);
+    }
+
+    /**
+     * @return string
+     */
+    public function getBillingCountry()
+    {
+        return $this->getParameter('billingCountry');
+    }
+
+    /**
+     * @param string $locale
+     * @return $this
+     */
+    public function setLocale($locale)
+    {
+        return $this->setParameter('locale', $locale);
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->getParameter('locale');
+    }
+
+    /**
      * @param string $resource
      * @return $this
      */
-    public function setResource(string $resource)
+    public function setResource($resource)
     {
         return $this->setParameter('resource', $resource);
     }
@@ -31,6 +65,23 @@ class FetchPaymentMethodsRequest extends AbstractMollieRequest
     }
 
     /**
+     * @param $sequenceType
+     * @return $this
+     */
+    public function setSequenceType($sequenceType)
+    {
+        return $this->setParameter('sequenceType', $sequenceType);
+    }
+
+    /**
+     * @return string
+     */
+    public function getSequenceType()
+    {
+        return $this->getParameter('sequenceType');
+    }
+
+    /**
      * @return array
      * @throws InvalidRequestException
      */
@@ -38,8 +89,23 @@ class FetchPaymentMethodsRequest extends AbstractMollieRequest
     {
         $this->validate('apiKey');
 
+        // Currency and amount are optional but both required when either one is supplied
+        $amount = null;
+        if ($this->getAmount() || $this->getCurrency()) {
+            $this->validate('amount', 'currency');
+
+            $amount = [
+                'value' => $this->getAmount(),
+                'currency' => $this->getCurrency(),
+            ];
+        }
+
         return [
+            'amount' => $amount,
+            'billingCountry' => $this->getBillingCountry(),
+            'locale' => $this->getLocale(),
             'resource' => $this->getResource(),
+            'sequenceType' => $this->getSequenceType(),
         ];
     }
 
@@ -50,10 +116,7 @@ class FetchPaymentMethodsRequest extends AbstractMollieRequest
     public function sendData($data)
     {
         $query = http_build_query($data);
-        $response = $this->sendRequest(self::GET, sprintf(
-            '/methods%s',
-            ($query ? '?' . $query : '')
-        ));
+        $response = $this->sendRequest(self::GET, '/methods' . ($query ? '?' . $query : ''));
 
         return $this->response = new FetchPaymentMethodsResponse($this, $response);
     }


### PR DESCRIPTION
Mollie's payment method listing API call allows for a few query parameters to be supplied. These are not supported by omnipay-mollie. To work with the new orders API being implemented I need to be able to specify at least the `resource` query parameter to also include order-only payment methods in the result.

Without this parameter `klarnasliceit` and `klarnapaylater` will never show up in the request's result. I can not be sure whether they are enabled then.

Relevant Mollie API documentation https://docs.mollie.com/reference/v2/methods-api/list-methods.

If you want this change I can help by improving on this PR, which I made to indicate my intentions.