### PR TITLE
Implement void method for order API

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ $response = $gateway->createShipment(
 )->send();
 ```
 
+4. As long as the order is `created`, `authorized` or `shipping`, it may be cancelled (voided) 
+
+```php
+$response = $gateway->void(["transactionReference" => "ord_xxx"])->send();
+```
+
 ## Support
 
 If you are having general issues with Omnipay, we suggest posting on

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -4,6 +4,7 @@ namespace Omnipay\Mollie;
 
 use Omnipay\Common\AbstractGateway;
 use Omnipay\Common\Message\RequestInterface;
+use Omnipay\Mollie\Message\Request\CancelOrderRequest;
 use Omnipay\Mollie\Message\Request\CompleteOrderRequest;
 use Omnipay\Mollie\Message\Request\CompletePurchaseRequest;
 use Omnipay\Mollie\Message\Request\CreateCustomerMandateRequest;
@@ -31,7 +32,6 @@ use Omnipay\Mollie\Message\Request\UpdateCustomerRequest;
  * @method RequestInterface authorize(array $options = array())
  * @method RequestInterface completeAuthorize(array $options = array())
  * @method RequestInterface capture(array $options = array())
- * @method RequestInterface void(array $options = array())
  * @method RequestInterface createCard(array $options = array())
  * @method RequestInterface updateCard(array $options = array())
  * @method RequestInterface deleteCard(array $options = array())
@@ -258,5 +258,14 @@ class Gateway extends AbstractGateway
     public function revokeCustomerMandate(array $parameters = [])
     {
         return $this->createRequest(RevokeCustomerMandateRequest::class, $parameters);
+    }
+
+    /**
+     * @param  array $parameters
+     * @return CancelOrderRequest
+     */
+    public function void(array $parameters = [])
+    {
+        return $this->createRequest(CancelOrderRequest::class, $parameters);
     }
 }

--- a/src/Message/Request/CancelOrderRequest.php
+++ b/src/Message/Request/CancelOrderRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Omnipay\Mollie\Message\Request;
+
+use Omnipay\Mollie\Message\Response\CancelOrderResponse;
+
+/**
+ * Cancel an order with the Mollie API.
+ *
+ * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order
+ * @method CancelOrderResponse send()
+ */
+final class CancelOrderRequest extends AbstractMollieRequest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getData()
+    {
+        $this->validate('apiKey', 'transactionReference');
+
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function sendData($data)
+    {
+        return $this->response = new CancelOrderResponse(
+            $this,
+            $this->sendRequest(self::DELETE, '/orders/'.$this->getTransactionReference(), $data)
+        );
+    }
+}

--- a/src/Message/Response/CancelOrderResponse.php
+++ b/src/Message/Response/CancelOrderResponse.php
@@ -12,6 +12,10 @@ final class CancelOrderResponse extends FetchOrderResponse
      */
     public function isSuccessful()
     {
-        return 'canceled' === $this->data['status'] ?? '';
+        if (!isset($this->data['status'])) {
+            return false;
+        }
+
+        return 'canceled' === $this->data['status'];
     }
 }

--- a/src/Message/Response/CancelOrderResponse.php
+++ b/src/Message/Response/CancelOrderResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Omnipay\Mollie\Message\Response;
+
+/**
+ * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order
+ */
+final class CancelOrderResponse extends FetchOrderResponse
+{
+    /**
+     * @return bool
+     */
+    public function isSuccessful()
+    {
+        return 'canceled' === $this->data['status'] ?? '';
+    }
+}

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -4,6 +4,7 @@ namespace Omnipay\Mollie\Test;
 
 use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Mollie\Gateway;
+use Omnipay\Mollie\Message\Request\CancelOrderRequest;
 use Omnipay\Mollie\Message\Request\CompletePurchaseRequest;
 use Omnipay\Mollie\Message\Request\CreateCustomerMandateRequest;
 use Omnipay\Mollie\Message\Request\CreateCustomerRequest;
@@ -211,5 +212,10 @@ class GatewayTest extends GatewayTestCase
         );
 
         $this->assertInstanceOf(CreateCustomerMandateRequest::class, $request);
+    }
+
+    public function testVoid()
+    {
+        $this->assertInstanceOf(CancelOrderRequest::class, $this->gateway->void());
     }
 }

--- a/tests/Message/CancelOrderRequestTest.php
+++ b/tests/Message/CancelOrderRequestTest.php
@@ -26,7 +26,7 @@ final class CancelOrderRequestTest extends TestCase
         $this->request = new CancelOrderRequest($this->httpClient, $this->getHttpRequest());
     }
 
-    public function insufficientDataProvider(): array
+    public function insufficientDataProvider()
     {
         return [
             [['apiKey' => 'mykey']],
@@ -34,7 +34,7 @@ final class CancelOrderRequestTest extends TestCase
         ];
     }
 
-    public function responseDataProvider(): array
+    public function responseDataProvider()
     {
         return [
             [['id' => 'ord_kEn1PlbGa'], false],
@@ -65,7 +65,7 @@ final class CancelOrderRequestTest extends TestCase
     /**
      * @dataProvider responseDataProvider
      */
-    public function testSendData(array $responseData, bool $success)
+    public function testSendData(array $responseData, $success)
     {
         $response = $this->createMock(ResponseInterface::class);
         $response->expects(self::once())
@@ -80,7 +80,6 @@ final class CancelOrderRequestTest extends TestCase
                 ['Authorization' => 'Bearer mykey']
             )->willReturn($response);
 
-
         $this->request->initialize(['apiKey' => 'mykey', 'transactionReference' => 'ord_kEn1PlbGa']);
         $voidResponse = $this->request->sendData([]);
 
@@ -88,5 +87,4 @@ final class CancelOrderRequestTest extends TestCase
         $this->assertEquals($success, $voidResponse->isSuccessful());
         $this->assertSame('ord_kEn1PlbGa', $voidResponse->getTransactionReference());
     }
-
 }

--- a/tests/Message/CancelOrderRequestTest.php
+++ b/tests/Message/CancelOrderRequestTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Omnipay\Mollie\Test\Message;
+
+use Omnipay\Common\Http\ClientInterface;
+use Omnipay\Mollie\Message\Request\CancelOrderRequest;
+use Omnipay\Mollie\Message\Response\CancelOrderResponse;
+use Omnipay\Tests\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+final class CancelOrderRequestTest extends TestCase
+{
+    /**
+     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $httpClient;
+
+    /**
+     * @var CancelOrderRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->request = new CancelOrderRequest($this->httpClient, $this->getHttpRequest());
+    }
+
+    public function insufficientDataProvider(): array
+    {
+        return [
+            [['apiKey' => 'mykey']],
+            [['transactionReference' => 'myref']],
+        ];
+    }
+
+    public function responseDataProvider(): array
+    {
+        return [
+            [['id' => 'ord_kEn1PlbGa'], false],
+            [['status' => 'paid', 'id' => 'ord_kEn1PlbGa'], false],
+            [['status' => 'canceled', 'id' => 'ord_kEn1PlbGa'], true],
+        ];
+    }
+
+    /**
+     * @dataProvider insufficientDataProvider
+     *
+     * @expectedException \Omnipay\Common\Exception\InvalidRequestException
+     *
+     * @param array $input
+     */
+    public function testGetDataWillValidateRequiredData(array $input)
+    {
+        $this->request->initialize($input);
+        $this->request->getData();
+    }
+
+    public function testGetDataWillReturnEmptyArray()
+    {
+        $this->request->initialize(['apiKey' => 'mykey', 'transactionReference' => 'myref']);
+        self::assertEquals([], $this->request->getData());
+    }
+
+    /**
+     * @dataProvider responseDataProvider
+     */
+    public function testSendData(array $responseData, bool $success)
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects(self::once())
+            ->method('getBody')
+            ->willReturn(\json_encode($responseData));
+
+        $this->httpClient->expects(self::once())
+            ->method('request')
+            ->with(
+                'DELETE',
+                'https://api.mollie.com/v2/orders/ord_kEn1PlbGa',
+                ['Authorization' => 'Bearer mykey']
+            )->willReturn($response);
+
+
+        $this->request->initialize(['apiKey' => 'mykey', 'transactionReference' => 'ord_kEn1PlbGa']);
+        $voidResponse = $this->request->sendData([]);
+
+        $this->assertInstanceOf(CancelOrderResponse::class, $voidResponse);
+        $this->assertEquals($success, $voidResponse->isSuccessful());
+        $this->assertSame('ord_kEn1PlbGa', $voidResponse->getTransactionReference());
+    }
+
+}


### PR DESCRIPTION
I'd like to add this implementation of the void method, to be able to void orders that have been created and/or authorized