### PR TITLE
Add Apple Pay support to FetchPaymentMethodsRequest

### DIFF
--- a/src/Message/Request/FetchPaymentMethodsRequest.php
+++ b/src/Message/Request/FetchPaymentMethodsRequest.php
@@ -32,6 +32,23 @@ class FetchPaymentMethodsRequest extends AbstractMollieRequest
     }
 
     /**
+     * @param string $includeWallets
+     * @return $this
+     */
+    public function setIncludeWallets($includeWallets)
+    {
+        return $this->setParameter('includeWallets', $includeWallets);
+    }
+
+    /**
+     * @return string
+     */
+    public function getIncludeWallets()
+    {
+        return $this->getParameter('includeWallets');
+    }
+
+    /**
      * @param string $locale
      * @return $this
      */
@@ -106,6 +123,7 @@ class FetchPaymentMethodsRequest extends AbstractMollieRequest
             'billingCountry' => $this->getBillingCountry(),
             'locale' => $this->getLocale(),
             'resource' => $this->getResource(),
+            'includeWallets' => $this->getIncludeWallets(),
             'sequenceType' => $this->getSequenceType(),
         ];
     }

--- a/tests/Message/FetchPaymentMethodsRequestTest.php
+++ b/tests/Message/FetchPaymentMethodsRequestTest.php
@@ -13,7 +13,7 @@ class FetchPaymentMethodsRequestTest extends TestCase
 {
     use AssertRequestTrait;
 
-    protected static $expectedRequestUri = 'https://api.mollie.com/v2/methods?amount%5Bvalue%5D=22.56&amount%5Bcurrency%5D=SEK&billingCountry=SE&locale=sv_SE&resource=orders&sequenceType=oneoff';
+    protected static $expectedRequestUri = 'https://api.mollie.com/v2/methods?amount%5Bvalue%5D=22.56&amount%5Bcurrency%5D=SEK&billingCountry=SE&locale=sv_SE&resource=orders&includeWallets=applepay&sequenceType=oneoff';
 
     /**
      * @var FetchPaymentMethodsRequest
@@ -31,6 +31,7 @@ class FetchPaymentMethodsRequestTest extends TestCase
             'locale' => 'sv_SE',
             'resource' => 'orders',
             'sequenceType' => 'oneoff',
+            'includeWallets' => 'applepay',
         ]);
     }
 
@@ -47,6 +48,7 @@ class FetchPaymentMethodsRequestTest extends TestCase
         $this->assertSame('sv_SE', $data['locale']);
         $this->assertSame('orders', $data['resource']);
         $this->assertSame('oneoff', $data['sequenceType']);
+        $this->assertSame('applepay', $data['includeWallets']);
     }
 
     /**
@@ -98,9 +100,9 @@ class FetchPaymentMethodsRequestTest extends TestCase
         $paymentMethods = $response->getPaymentMethods();
         $this->assertCount(12, $paymentMethods);
 
-        $expectedPaymentMethod = new PaymentMethod('ideal', 'iDEAL');
+        $paymentMethod = new PaymentMethod('ideal', 'iDEAL');
 
-        $this->assertEquals($expectedPaymentMethod, $paymentMethods[0]);
+        $this->assertEquals($paymentMethod, $paymentMethods[0]);
     }
 
     public function testSendFailure()


### PR DESCRIPTION
Allows the `includeWallets` query parameter in the payment method request as per https://docs.mollie.com/wallets/applepay

Basically all this does is allow the parameter so
```php
$gateway->fetchPaymentMethods([
    'includeWallets' => 'applepay',
]);
```
is allowed to return "applepay" as a payment method.