### PR TITLE
Add 'created' status for Mollie Orders API

### DIFF
--- a/src/Message/Response/FetchTransactionResponse.php
+++ b/src/Message/Response/FetchTransactionResponse.php
@@ -58,7 +58,7 @@ class FetchTransactionResponse extends AbstractMollieResponse implements Redirec
      */
     public function isOpen()
     {
-        return isset($this->data['status']) && 'open' === $this->data['status'];
+        return isset($this->data['status']) && ('open' === $this->data['status'] || 'created' === $this->data['status']);
     }
 
     /**

--- a/src/Message/Response/FetchTransactionResponse.php
+++ b/src/Message/Response/FetchTransactionResponse.php
@@ -58,7 +58,8 @@ class FetchTransactionResponse extends AbstractMollieResponse implements Redirec
      */
     public function isOpen()
     {
-        return isset($this->data['status']) && ('open' === $this->data['status'] || 'created' === $this->data['status']);
+        return isset($this->data['status'])
+            && ('open' === $this->data['status'] || 'created' === $this->data['status']);
     }
 
     /**

--- a/tests/Message/CompleteOrderRequestTest.php
+++ b/tests/Message/CompleteOrderRequestTest.php
@@ -64,7 +64,7 @@ class CompleteOrderRequestTest extends TestCase
 
         $this->assertInstanceOf(CompleteOrderResponse::class, $response);
         $this->assertFalse($response->isSuccessful());
-        $this->assertFalse($response->isOpen());
+        $this->assertTrue($response->isOpen());
         $this->assertFalse($response->isPaid());
         $this->assertFalse($response->isRedirect());
         $this->assertSame('ord_kEn1PlbGa', $response->getTransactionReference());

--- a/tests/Message/CreateOrderRequestTest.php
+++ b/tests/Message/CreateOrderRequestTest.php
@@ -215,7 +215,7 @@ class CreateOrderRequestTest extends TestCase
         $this->assertNull($response->getRedirectData());
         $this->assertSame('ord_pbjz8x', $response->getTransactionReference());
         $this->assertSame('created' ,$response->getStatus());
-        $this->assertFalse($response->isOpen());
+        $this->assertTrue($response->isOpen());
         $this->assertFalse($response->isPaid());
         $this->assertNull($response->getCode());
     }


### PR DESCRIPTION
When using Mollie's Orders API, the status for open orders is "created" instead of "open", see https://docs.mollie.com/orders/status-changes

EDIT: I fixed the tests as the status "created" means the order is open IMHO. The previous test for `status == 'open'` was useless as the Orders API will never return "open" as a status.