### PR TITLE
Add versionString on request of Mollie

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -41,6 +41,11 @@ use Omnipay\Mollie\Message\Request\UpdateCustomerRequest;
 class Gateway extends AbstractGateway
 {
     /**
+     * Version of our gateway.
+     */
+    const GATEWAY_VERSION = "5.1.1";
+
+    /**
      * @return string
      */
     public function getName()

--- a/src/Message/Request/AbstractMollieRequest.php
+++ b/src/Message/Request/AbstractMollieRequest.php
@@ -4,6 +4,7 @@ namespace Omnipay\Mollie\Message\Request;
 
 use Omnipay\Common\ItemBag;
 use Omnipay\Common\Message\AbstractRequest;
+use Omnipay\Mollie\Gateway;
 use Omnipay\Mollie\Item;
 
 /**
@@ -89,12 +90,25 @@ abstract class AbstractMollieRequest extends AbstractRequest
      */
     protected function sendRequest($method, $endpoint, array $data = null)
     {
+        $versions = [
+            'Omnipay-Mollie/' . Gateway::GATEWAY_VERSION,
+            'PHP/' . phpversion(),
+        ];
+
+        $headers = [
+            'Accept' => "application/json",
+            'Authorization' => 'Bearer ' . $this->getApiKey(),
+            'User-Agent' => implode(' ', $versions),
+        ];
+
+        if (function_exists("php_uname")) {
+            $headers['X-Mollie-Client-Info'] = php_uname();
+        }
+
         $response = $this->httpClient->request(
             $method,
             $this->baseUrl . $this->apiVersion . $endpoint,
-            [
-                'Authorization' => 'Bearer ' . $this->getApiKey()
-            ],
+            $headers,
             ($data === null || $data === []) ? null : json_encode($data)
         );
 

--- a/tests/Message/AbstractMollieRequestTest.php
+++ b/tests/Message/AbstractMollieRequestTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Omnipay\Mollie\Test\Message;
+
+use GuzzleHttp\Psr7\Request;
+use Omnipay\Mollie\Gateway;
+use Omnipay\Mollie\Message\Request\CompleteOrderRequest;
+use Omnipay\Mollie\Message\Request\CompletePurchaseRequest;
+use Omnipay\Mollie\Message\Response\CompleteOrderResponse;
+use Omnipay\Mollie\Message\Response\CompletePurchaseResponse;
+use Omnipay\Tests\TestCase;
+
+class AbstractMollieRequestTest extends TestCase
+{
+    /**
+     * @var Gateway
+     */
+    protected $gateway;
+
+    public function setUp()
+    {
+        $this->gateway = new Gateway($this->getHttpClient());
+    }
+
+
+    public function testVersionString()
+    {
+        $request = $this->gateway->fetchIssuers();
+        $request->send();
+
+        /** @var \Psr\Http\Message\RequestInterface $httpRequest */
+        $httpRequest = $this->getMockedRequests()[0];
+
+        $versionString = 'Omnipay-Mollie/'.Gateway::GATEWAY_VERSION.' PHP/' . phpversion();
+        $this->assertEquals($versionString, $httpRequest->getHeaderLine('User-Agent'));
+    }
+
+}

--- a/tests/Message/FetchOrderRequestTest.php
+++ b/tests/Message/FetchOrderRequestTest.php
@@ -105,7 +105,9 @@ class FetchOrderRequestTest extends TestCase
             ->with(
                 FetchOrderRequest::GET,
                 'https://api.mollie.com/v2/orders/ord_kEn1PlbGa?embed=payments',
-                ['Authorization' => 'Bearer mykey'],
+                $this->callback(function ($headers) {
+                    return $headers['Authorization'] == 'Bearer mykey';
+                }),
                 null
             )->willReturn($clientResponse);
 


### PR DESCRIPTION
Add version string to the UserAgent for Mollie debugging.

Downside; because we use different HTTP Client, the UserAgent cannot be filled by the HttpClient, so we lose the actual client information.

If possible, we would add the versions in a custom header (eg. `X-Mollie-Client-Version` ?)