### PR TITLE
Added Content-Type header

### DIFF
--- a/src/Message/Request/AbstractMollieRequest.php
+++ b/src/Message/Request/AbstractMollieRequest.php
@@ -118,6 +118,7 @@ abstract class AbstractMollieRequest extends AbstractRequest
 
         $headers = [
             'Accept' => "application/json",
+            'Content-Type' => "application/json",
             'Authorization' => 'Bearer ' . $this->getApiKey(),
             'User-Agent' => implode(' ', $versions),
         ];


### PR DESCRIPTION
A `POST` request to `/customers` resulted into the following `400 Bad Request` response:

```
{
    "status": 400,
    "title": "Bad Request",
    "detail": "Expected URL encoded form data, got JSON. Set the "Content-Type" header to "application/json" when sending JSON encoded data.",
    "_links": {
        "documentation": {
            "href": "https://docs.mollie.com/guides/handling-errors",
            "type": "text/html"
        }
    }
}
```

After adding the `Content-Type` header the request was successful :)