### PR TITLE
Adding support for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,15 +33,15 @@
         "psr-4": { "Omnipay\\Mollie\\Test\\": "tests/" }
     },
     "require": {
-        "omnipay/common": "^3.0.1"
+        "omnipay/common": "^3.1"
     },
     "require-dev": {
-        "omnipay/tests": "^3.1",
         "squizlabs/php_codesniffer": "^3",
-        "phpro/grumphp": "^0.14",
+        "phpro/grumphp": "^1.3",
         "phpmd/phpmd": "^2",
         "overtrue/phplint": "^1",
-        "jakub-onderka/php-parallel-lint": "^1"
+        "jakub-onderka/php-parallel-lint": "^1",
+        "omnipay/tests": "^4.0"
     },
     "extra": {
         "branch-alias": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,4 @@
-parameters:
-    git_dir: .
-    bin_dir: vendor/bin
+grumphp:
     tasks:
         phpunit:
             config_file: ~


### PR DESCRIPTION
This removes support for PHP <= 7.2 though. I had no clue what to do with grumphp. Updated the configuration to make it stop nagging about deprecated stuff in grumphp.yml.