### PR TITLE
Add cardToken to order and payment request

### DIFF
--- a/src/Message/Request/CreateOrderRequest.php
+++ b/src/Message/Request/CreateOrderRequest.php
@@ -128,6 +128,23 @@ class CreateOrderRequest extends AbstractMollieRequest
     }
 
     /**
+     * @return string
+     */
+    public function getCardToken()
+    {
+        return $this->getParameter('cardToken');
+    }
+
+    /**
+     * @param string $value
+     * @return $this
+     */
+    public function setCardToken($value)
+    {
+        return $this->setParameter('cardToken', $value);
+    }
+
+    /**
      * Alias for lines
      *
      * @param $items
@@ -197,6 +214,10 @@ class CreateOrderRequest extends AbstractMollieRequest
 
         if ($sequenceType = $this->getSequenceType()) {
             $data['payment']['sequenceType'] = $sequenceType;
+        }
+
+        if ($cardToken = $this->getCardToken()) {
+            $data['payment']['cardToken'] = $cardToken;
         }
 
         return array_filter($data);

--- a/src/Message/Request/PurchaseRequest.php
+++ b/src/Message/Request/PurchaseRequest.php
@@ -119,6 +119,23 @@ class PurchaseRequest extends AbstractMollieRequest
     /**
      * @return string
      */
+    public function getCardToken()
+    {
+        return $this->getParameter('cardToken');
+    }
+
+    /**
+     * @param string $value
+     * @return $this
+     */
+    public function setCardToken($value)
+    {
+        return $this->setParameter('cardToken', $value);
+    }
+
+    /**
+     * @return string
+     */
     public function getInclude()
     {
         return $this->getParameter('include');
@@ -183,6 +200,10 @@ class PurchaseRequest extends AbstractMollieRequest
         
         if ($mandateId = $this->getMandateId()) {
             $data['mandateId'] = $mandateId;
+        }
+
+        if ($cardToken = $this->getCardToken()) {
+            $data['cardToken'] = $cardToken;
         }
 
         return $data;


### PR DESCRIPTION
Hey,
We got the request from Mollie to add the support for [Mollie components](https://docs.mollie.com/components/overview) to our [Craft CMS plugin](https://plugins.craftcms.com/commerce-mollie-plus).
This PR adds to option to pass the necessary cardToken parameter to both the payment as order API