### PR TITLE
[4.x] Check if body is not null (eg. GET request)

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -34,7 +34,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             array(
                 'Authorization' => 'Bearer ' . $this->getApiKey()
             ),
-            json_encode($data)
+            $data !== null ? json_encode($data) : null
         );
 
         return json_decode($response->getBody(), true);


### PR DESCRIPTION
Prevent **400 Bad Request** when completing the payment. Mollie response: `Your client has issued a malformed or illegal request.` which results in a JSON parse error: `Omnipay\Common\Exception\RuntimeException: Unable to parse response body into JSON: 4 in ...`

Response from Mollie (translated)

> The V1 API has not changed, but the loadbalancer now rejects GET requests with a body. Make sure your client sends GET requests without body.

This affects 4.x branch, which isn't the current branch, but still problematic for older projects.