### PR TITLE
Fix incompatible override of `getRedirectData()` in `FetchTransactionResponse`

### DIFF
--- a/src/Message/Response/FetchTransactionResponse.php
+++ b/src/Message/Response/FetchTransactionResponse.php
@@ -40,14 +40,6 @@ class FetchTransactionResponse extends AbstractMollieResponse implements Redirec
     /**
      * {@inheritdoc}
      */
-    public function getRedirectData()
-    {
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function isSuccessful()
     {
         return parent::isSuccessful();

--- a/tests/Message/CreateOrderRequestTest.php
+++ b/tests/Message/CreateOrderRequestTest.php
@@ -212,7 +212,7 @@ class CreateOrderRequestTest extends TestCase
         $this->assertTrue($response->isRedirect());
         $this->assertSame('GET', $response->getRedirectMethod());
         $this->assertSame('https://www.mollie.com/payscreen/order/checkout/pbjz8x', $response->getRedirectUrl());
-        $this->assetEmpty($response->getRedirectData());
+        $this->assertEmpty($response->getRedirectData());
         $this->assertSame('ord_pbjz8x', $response->getTransactionReference());
         $this->assertSame('created' ,$response->getStatus());
         $this->assertTrue($response->isOpen());

--- a/tests/Message/CreateOrderRequestTest.php
+++ b/tests/Message/CreateOrderRequestTest.php
@@ -212,7 +212,7 @@ class CreateOrderRequestTest extends TestCase
         $this->assertTrue($response->isRedirect());
         $this->assertSame('GET', $response->getRedirectMethod());
         $this->assertSame('https://www.mollie.com/payscreen/order/checkout/pbjz8x', $response->getRedirectUrl());
-        $this->assertNull($response->getRedirectData());
+        $this->assetEmpty($response->getRedirectData());
         $this->assertSame('ord_pbjz8x', $response->getTransactionReference());
         $this->assertSame('created' ,$response->getStatus());
         $this->assertTrue($response->isOpen());

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -163,7 +163,7 @@ class PurchaseRequestTest extends TestCase
         $this->assertTrue($response->isRedirect());
         $this->assertSame('GET', $response->getRedirectMethod());
         $this->assertSame('https://www.mollie.com/payscreen/select-method/7UhSN1zuXS', $response->getRedirectUrl());
-        $this->assertNull($response->getRedirectData());
+        $this->assertEmpty($response->getRedirectData());
         $this->assertSame('tr_7UhSN1zuXS', $response->getTransactionReference());
         $this->assertTrue($response->isOpen());
         $this->assertFalse($response->isPaid());
@@ -227,7 +227,7 @@ class PurchaseRequestTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertNull($response->getRedirectUrl());
-        $this->assertNull($response->getRedirectData());
+        $this->assertEmpty($response->getRedirectData());
         $this->assertSame('{"status":422,"title":"Unprocessable Entity","detail":"The payment method is invalid","field":"method","_links":{"documentation":{"href":"https:\/\/docs.mollie.com\/guides\/handling-errors","type":"text\/html"}}}', $response->getMessage());
     }
 }


### PR DESCRIPTION
Currently `FetchTransactionResponse` is redeclaring the `getRedirectData()` method and always returning `null`.

This return type does not match the documented and implemented return in Omnipay Common's `AbstractResponse`

See here: https://github.com/thephpleague/omnipay-common/blob/master/src/Common/Message/AbstractResponse.php#L179-L187

This PR fixes the issue by removing the redeclaration of the method in the class as the inherited implementation does everything that is required.